### PR TITLE
Add minimal web server for automated PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is the home of the **Codex CLI**, which is a coding agent from OpenAI that 
 - [CLI reference](#cli-reference)
 - [Memory & project docs](#memory--project-docs)
 - [Non-interactive / CI mode](#non-interactive--ci-mode)
+- [Web server automation](#web-server-automation)
 - [Model Context Protocol (MCP)](#model-context-protocol-mcp)
 - [Tracing / verbose logging](#tracing--verbose-logging)
 - [Recipes](#recipes)
@@ -272,6 +273,20 @@ Run Codex head-less in pipelines. Example GitHub Action step:
     export OPENAI_API_KEY="${{ secrets.OPENAI_KEY }}"
     codex exec --full-auto "update CHANGELOG for next release"
 ```
+## Web server automation
+
+A minimal Express server lives in `web-server/`. Set `OPENAI_API_KEY` in your environment, then run:
+
+```bash
+cd web-server
+pnpm install
+pnpm start
+```
+
+Open <http://localhost:3000> and submit a repository URL, prompt and GitHub token. The server clones the repository, runs Codex, commits the result and opens a pull request.
+
+**Security note:** the server executes commands and uses your token for pushes. Only run it with repositories and credentials you trust.
+
 
 ## Model Context Protocol (MCP)
 

--- a/web-server/git-helpers.js
+++ b/web-server/git-helpers.js
@@ -1,0 +1,135 @@
+import { spawnSync } from 'child_process';
+import { Octokit } from '@octokit/rest';
+
+function runGit(args, silent = true) {
+  console.info(`Running git ${args.join(' ')}`);
+  const res = spawnSync('git', args, {
+    encoding: 'utf8',
+    stdio: silent ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  });
+  if (res.error) {
+    throw res.error;
+  }
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed with code ${res.status}: ${res.stderr}`);
+  }
+  return res.stdout.trim();
+}
+
+export function stageAllChanges() {
+  runGit(['add', '-A']);
+}
+
+function hasStagedChanges() {
+  const res = spawnSync('git', ['diff', '--cached', '--quiet', '--exit-code']);
+  return res.status !== 0;
+}
+
+function ensureOnBranch(issueNumber, protectedBranches, suggestedSlug) {
+  let branch = '';
+  try {
+    branch = runGit(['symbolic-ref', '--short', '-q', 'HEAD']);
+  } catch {
+    branch = '';
+  }
+  if (!branch || protectedBranches.includes(branch)) {
+    if (suggestedSlug) {
+      const safeSlug = suggestedSlug
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-');
+      branch = `codex-fix-${issueNumber}-${safeSlug}`;
+    } else {
+      branch = `codex-fix-${issueNumber}-${Date.now()}`;
+    }
+    runGit(['switch', '-c', branch]);
+  }
+  return branch;
+}
+
+function commitIfNeeded(issueNumber) {
+  if (hasStagedChanges()) {
+    runGit(['commit', '-m', `fix: automated fix for #${issueNumber} via Codex`]);
+  }
+}
+
+function pushBranch(branch, githubToken, ctx) {
+  const repoSlug = ctx.get('GITHUB_REPOSITORY');
+  const remoteUrl = `https://x-access-token:${githubToken}@github.com/${repoSlug}.git`;
+  runGit(['push', '--force-with-lease', '-u', remoteUrl, `HEAD:${branch}`]);
+}
+
+export async function maybePublishPRForIssue(issueNumber, lastMessage, ctx) {
+  const githubToken = ctx.tryGetNonEmpty('GITHUB_TOKEN') || ctx.tryGetNonEmpty('GH_TOKEN');
+  if (!githubToken) {
+    console.warn('No GitHub token - skipping PR creation.');
+    return undefined;
+  }
+
+  runGit(['status']);
+  stageAllChanges();
+
+  const octokit = ctx.getOctokit(githubToken);
+  const [owner, repo] = ctx.get('GITHUB_REPOSITORY').split('/');
+
+  let defaultBranch = 'main';
+  try {
+    const repoInfo = await octokit.repos.get({ owner, repo });
+    defaultBranch = repoInfo.data.default_branch || 'main';
+  } catch (e) {
+    console.warn(`Failed to get default branch, assuming 'main': ${e}`);
+  }
+
+  const sanitizedMessage = lastMessage.replace(/\u2022/g, '-');
+  const [summaryLine] = sanitizedMessage.split(/\r?\n/);
+  const branch = ensureOnBranch(issueNumber, [defaultBranch, 'master'], summaryLine);
+  commitIfNeeded(issueNumber);
+  pushBranch(branch, githubToken, ctx);
+
+  const headParam = `${owner}:${branch}`;
+  const existing = await octokit.pulls.list({ owner, repo, head: headParam, state: 'open' });
+  if (existing.data.length > 0) {
+    return existing.data[0].html_url;
+  }
+
+  let baseBranch = 'main';
+  try {
+    const repoInfo = await octokit.repos.get({ owner, repo });
+    baseBranch = repoInfo.data.default_branch || 'main';
+  } catch (e) {
+    console.warn(`Failed to get default branch, assuming 'main': ${e}`);
+  }
+
+  const pr = await octokit.pulls.create({
+    owner,
+    repo,
+    title: summaryLine,
+    head: branch,
+    base: baseBranch,
+    body: sanitizedMessage,
+  });
+  return pr.data.html_url;
+}
+
+export function createEnvContext(env = process.env) {
+  return {
+    get(name) {
+      const value = env[name];
+      if (value == null) throw new Error(`Missing required env var: ${name}`);
+      return value;
+    },
+    tryGet(name) {
+      return env[name];
+    },
+    tryGetNonEmpty(name) {
+      const v = env[name];
+      return v == null || v === '' ? null : v;
+    },
+    getOctokit(token) {
+      const auth = token || env['GITHUB_TOKEN'] || env['GH_TOKEN'];
+      if (!auth) throw new Error('Missing GitHub token');
+      return new Octokit({ auth });
+    },
+  };
+}

--- a/web-server/package.json
+++ b/web-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex-web-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "@octokit/rest": "^20.0.0"
+  }
+}

--- a/web-server/public/index.html
+++ b/web-server/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Codex Web Runner</title>
+</head>
+<body>
+  <h1>Run Codex</h1>
+  <form id="run-form">
+    <label>Repository URL:<br /><input type="text" id="repoUrl" /></label><br />
+    <label>Prompt:<br /><textarea id="prompt" rows="4" cols="50"></textarea></label><br />
+    <label>GitHub Token:<br /><input type="password" id="token" /></label><br />
+    <button type="submit">Run</button>
+  </form>
+  <pre id="result"></pre>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/web-server/public/main.js
+++ b/web-server/public/main.js
@@ -1,0 +1,20 @@
+const form = document.getElementById('run-form');
+const result = document.getElementById('result');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  result.textContent = 'Running...';
+  const repoUrl = document.getElementById('repoUrl').value;
+  const prompt = document.getElementById('prompt').value;
+  const token = document.getElementById('token').value;
+  const res = await fetch('/run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ repoUrl, prompt, token }),
+  });
+  if (res.ok) {
+    const data = await res.json();
+    result.textContent = data.prUrl ? `PR: ${data.prUrl}` : 'Done';
+  } else {
+    result.textContent = await res.text();
+  }
+});

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import { execSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { maybePublishPRForIssue, createEnvContext } from './git-helpers.js';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(path.dirname(new URL(import.meta.url).pathname), 'public')));
+
+app.post('/run', async (req, res) => {
+  const { repoUrl, prompt, token } = req.body;
+  if (!repoUrl || !prompt || !token) {
+    res.status(400).send('repoUrl, prompt and token are required');
+    return;
+  }
+
+  const workdir = path.join(os.tmpdir(), `codex-${Date.now()}`);
+  try {
+    const url = repoUrl.replace('https://', `https://${token}@`);
+    execSync(`git clone ${url} ${workdir}`, { stdio: 'inherit' });
+
+    execSync(`npx codex exec --full-auto "${prompt.replace(/"/g, '\"')}"`, {
+      cwd: workdir,
+      stdio: 'inherit',
+      env: { ...process.env, OPENAI_API_KEY: process.env.OPENAI_API_KEY || '' },
+    });
+
+    const ctx = createEnvContext({ ...process.env, GITHUB_TOKEN: token, GITHUB_REPOSITORY: repoUrl.split('github.com/')[1].replace(/\.git$/, '') });
+    const prUrl = await maybePublishPRForIssue(1, prompt, ctx);
+    res.json({ prUrl });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send(err.message);
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add `web-server` module with Express server
- add helper functions for git commits and PR creation
- serve basic HTML UI for submitting repo, prompt and token
- document how to run the server and update table of contents

## Testing
- `python3 scripts/readme_toc.py README.md`
- `./scripts/asciicheck.py README.md`


------
https://chatgpt.com/codex/tasks/task_e_6887238469d4832f8ab07521a0122c09