### PR TITLE
Add multi-user session handling to web server

### DIFF
--- a/web-server/public/index.html
+++ b/web-server/public/index.html
@@ -13,6 +13,7 @@
       <label>Repository URL:<br /><input type="text" id="repoUrl" required /></label><br />
       <label>Branch:<br /><input type="text" id="branch" value="main" required /></label><br />
       <label>GitHub Token:<br /><input type="password" id="token" required /></label><br />
+      <label>User ID:<br /><input type="text" id="userId" required /></label><br />
       <button type="submit">Save</button>
     </form>
   </div>

--- a/web-server/public/main.js
+++ b/web-server/public/main.js
@@ -5,6 +5,7 @@ const promptForm = document.getElementById('prompt-form');
 const repoInput = document.getElementById('repoUrl');
 const branchInput = document.getElementById('branch');
 const tokenInput = document.getElementById('token');
+const userIdInput = document.getElementById('userId');
 const promptInput = document.getElementById('prompt');
 const result = document.getElementById('result');
 const messages = document.getElementById('messages');
@@ -13,10 +14,12 @@ function loadSettings() {
   const repoUrl = localStorage.getItem('repoUrl');
   const token = localStorage.getItem('token');
   const branch = localStorage.getItem('branch') || 'main';
+  const userId = localStorage.getItem('userId');
   if (repoUrl && token) {
     repoInput.value = repoUrl;
     tokenInput.value = token;
     branchInput.value = branch;
+    if (userId) userIdInput.value = userId;
     setupDiv.style.display = 'none';
     conversationDiv.style.display = 'block';
   }
@@ -27,6 +30,7 @@ setupForm.addEventListener('submit', (e) => {
   localStorage.setItem('repoUrl', repoInput.value);
   localStorage.setItem('token', tokenInput.value);
   localStorage.setItem('branch', branchInput.value);
+  localStorage.setItem('userId', userIdInput.value);
   setupDiv.style.display = 'none';
   conversationDiv.style.display = 'block';
 });
@@ -41,10 +45,11 @@ promptForm.addEventListener('submit', async (e) => {
   const repoUrl = localStorage.getItem('repoUrl');
   const token = localStorage.getItem('token');
   const branch = localStorage.getItem('branch');
+  const userId = localStorage.getItem('userId');
   const res = await fetch('/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ repoUrl, prompt, token, branch }),
+    body: JSON.stringify({ repoUrl, prompt, token, branch, userId }),
   });
   if (res.ok) {
     const data = await res.json();

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -1,10 +1,22 @@
 import express from 'express';
-import { execSync } from 'child_process';
+import { spawn } from 'child_process';
 import path from 'path';
 import os from 'os';
+import fs from 'fs';
 import { maybePublishPRForIssue, createEnvContext } from './git-helpers.js';
 
-const repos = new Map();
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', ...options });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+const sessions = new Map();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -13,38 +25,55 @@ app.use(express.json());
 app.use(express.static(path.join(path.dirname(new URL(import.meta.url).pathname), 'public')));
 
 app.post('/run', async (req, res) => {
-  const { repoUrl, prompt, token, branch = 'main' } = req.body;
-  if (!repoUrl || !prompt || !token) {
-    res.status(400).send('repoUrl, prompt and token are required');
+  const { repoUrl, prompt, token, branch = 'main', userId } = req.body;
+  if (!repoUrl || !prompt || !token || !userId) {
+    res.status(400).send('repoUrl, prompt, token and userId are required');
     return;
   }
 
-  let repo = repos.get(repoUrl);
+  // ensure repo not used by another user
+  for (const [otherId, s] of sessions.entries()) {
+    if (otherId !== userId && s.repos && s.repos.has(repoUrl)) {
+      res.status(409).send('Repository in use by another user');
+      return;
+    }
+  }
+
+  let session = sessions.get(userId);
+  if (!session) {
+    session = { repos: new Map(), home: path.join(os.tmpdir(), `codex-home-${userId}`) };
+    sessions.set(userId, session);
+    await fs.promises.mkdir(session.home, { recursive: true });
+  }
+
+  let repo = session.repos.get(repoUrl);
   let workdir;
   if (!repo) {
-    workdir = path.join(os.tmpdir(), `codex-${Date.now()}`);
+    workdir = path.join(os.tmpdir(), `codex-${userId}-${Date.now()}`);
     const url = repoUrl.replace('https://', `https://${token}@`);
-    execSync(`git clone ${url} ${workdir}`, { stdio: 'inherit' });
+    await run('git', ['clone', url, workdir]);
     if (branch !== 'main') {
-      execSync(`git checkout -B ${branch}`, { cwd: workdir, stdio: 'inherit' });
+      await run('git', ['checkout', '-B', branch], { cwd: workdir });
     }
-    repos.set(repoUrl, { path: workdir, branch });
+    session.repos.set(repoUrl, { path: workdir, branch });
   } else {
     workdir = repo.path;
     try {
-      execSync(`git checkout ${repo.branch}`, { cwd: workdir, stdio: 'inherit' });
+      await run('git', ['checkout', repo.branch], { cwd: workdir });
     } catch {
-      execSync(`git checkout -B ${repo.branch}`, { cwd: workdir, stdio: 'inherit' });
+      await run('git', ['checkout', '-B', repo.branch], { cwd: workdir });
     }
-    execSync('git pull', { cwd: workdir, stdio: 'inherit' });
+    await run('git', ['pull'], { cwd: workdir });
   }
 
+  const env = {
+    ...process.env,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
+    CODEX_HOME: session.home,
+  };
+
   try {
-    execSync(`npx codex exec --full-auto "${prompt.replace(/"/g, '\"')}"`, {
-      cwd: workdir,
-      stdio: 'inherit',
-      env: { ...process.env, OPENAI_API_KEY: process.env.OPENAI_API_KEY || '' },
-    });
+    await run('npx', ['codex', 'exec', '--full-auto', prompt], { cwd: workdir, env });
 
     const ctx = createEnvContext({ ...process.env, GITHUB_TOKEN: token, GITHUB_REPOSITORY: repoUrl.split('github.com/')[1].replace(/\.git$/, '') });
     const prUrl = await maybePublishPRForIssue(1, prompt, ctx);


### PR DESCRIPTION
## Summary
- allow multiple Codex web sessions at once
- update UI to capture a User ID
- keep repos isolated per user and prevent clashes

## Testing
- `pnpm lint` *(fails: unable to download packages)*
- `pnpm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_688729702060832f9ad3616452ab1deb