### PR TITLE
Add Google OAuth & MongoDB chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Run Codex head-less in pipelines. Example GitHub Action step:
 ```
 ## Web server automation
 
-A minimal Express server lives in `web-server/`. Set `OPENAI_API_KEY` in your environment, then run:
+A minimal Express server lives in `web-server/`. Set `OPENAI_API_KEY` in your environment and provide `GOOGLE_CLIENT_ID` for OAuth along with an optional `MONGO_URL` (defaults to `mongodb://localhost:27017`). Then run:
 
 ```bash
 cd web-server
@@ -283,8 +283,8 @@ pnpm install
 pnpm start
 ```
 
-Open <http://localhost:3000> and enter your repository URL, branch and GitHub token once.
-After saving, you can send multiple prompts in the conversation UI.
+Open <http://localhost:3000>, sign in with your Google account and enter your repository URL, branch and GitHub token once.
+After saving, you can send multiple prompts in the conversation UI. Chat history for each `userId` and repository is persisted in the `codexdb` Mongo database.
 The server reuses the same clone and creates a pull request for each run.
 
 **Security note:** the server executes commands and uses your token for pushes. Only run it with repositories and credentials you trust.

--- a/web-server/package.json
+++ b/web-server/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "@octokit/rest": "^20.0.0"
+    "@octokit/rest": "^20.0.0",
+    "google-auth-library": "^9.0.0",
+    "mongodb": "^6.5.0"
   }
 }

--- a/web-server/public/index.html
+++ b/web-server/public/index.html
@@ -3,17 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <title>Codex Web Conversation</title>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 <body>
   <h1>Codex Web Conversation</h1>
 
-  <div id="setup">
+  <div id="login">
+    <div id="google-signin"></div>
+  </div>
+
+  <div id="setup" style="display:none;">
     <h2>Setup</h2>
     <form id="setup-form">
       <label>Repository URL:<br /><input type="text" id="repoUrl" required /></label><br />
       <label>Branch:<br /><input type="text" id="branch" value="main" required /></label><br />
       <label>GitHub Token:<br /><input type="password" id="token" required /></label><br />
-      <label>User ID:<br /><input type="text" id="userId" required /></label><br />
       <button type="submit">Save</button>
     </form>
   </div>

--- a/web-server/public/main.js
+++ b/web-server/public/main.js
@@ -1,3 +1,5 @@
+import { GOOGLE_CLIENT_ID } from './config.js';
+
 const setupDiv = document.getElementById('setup');
 const conversationDiv = document.getElementById('conversation');
 const setupForm = document.getElementById('setup-form');
@@ -5,23 +7,42 @@ const promptForm = document.getElementById('prompt-form');
 const repoInput = document.getElementById('repoUrl');
 const branchInput = document.getElementById('branch');
 const tokenInput = document.getElementById('token');
-const userIdInput = document.getElementById('userId');
+const loginDiv = document.getElementById('login');
 const promptInput = document.getElementById('prompt');
 const result = document.getElementById('result');
 const messages = document.getElementById('messages');
+
+function loadHistory(userId, repoUrl) {
+  if (!userId || !repoUrl) return;
+  fetch(`/history?userId=${encodeURIComponent(userId)}&repoUrl=${encodeURIComponent(repoUrl)}`)
+    .then((r) => r.ok ? r.json() : [])
+    .then((items) => {
+      messages.textContent = items.map((i) => `> ${i.prompt}${i.prUrl ? `\nPR: ${i.prUrl}` : ''}`).join('\n');
+    });
+}
 
 function loadSettings() {
   const repoUrl = localStorage.getItem('repoUrl');
   const token = localStorage.getItem('token');
   const branch = localStorage.getItem('branch') || 'main';
   const userId = localStorage.getItem('userId');
+  if (!userId) {
+    loginDiv.style.display = 'block';
+    setupDiv.style.display = 'none';
+    conversationDiv.style.display = 'none';
+    return;
+  }
+  loginDiv.style.display = 'none';
   if (repoUrl && token) {
     repoInput.value = repoUrl;
     tokenInput.value = token;
     branchInput.value = branch;
-    if (userId) userIdInput.value = userId;
     setupDiv.style.display = 'none';
     conversationDiv.style.display = 'block';
+    loadHistory(userId, repoUrl);
+  } else {
+    setupDiv.style.display = 'block';
+    conversationDiv.style.display = 'none';
   }
 }
 
@@ -30,9 +51,10 @@ setupForm.addEventListener('submit', (e) => {
   localStorage.setItem('repoUrl', repoInput.value);
   localStorage.setItem('token', tokenInput.value);
   localStorage.setItem('branch', branchInput.value);
-  localStorage.setItem('userId', userIdInput.value);
   setupDiv.style.display = 'none';
   conversationDiv.style.display = 'block';
+  const userId = localStorage.getItem('userId');
+  loadHistory(userId, repoInput.value);
 });
 
 promptForm.addEventListener('submit', async (e) => {
@@ -57,9 +79,30 @@ promptForm.addEventListener('submit', async (e) => {
       messages.textContent += `\nPR: ${data.prUrl}`;
     }
     result.textContent = 'Done';
+    loadHistory(userId, repoUrl);
   } else {
     result.textContent = await res.text();
   }
 });
 
 loadSettings();
+
+google.accounts.id.initialize({
+  client_id: GOOGLE_CLIENT_ID,
+  callback: async (response) => {
+    const res = await fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ idToken: response.credential }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('userId', data.userId);
+      loadSettings();
+    } else {
+      alert('Login failed');
+    }
+  },
+});
+
+google.accounts.id.renderButton(document.getElementById('google-signin'), { theme: 'outline', size: 'large' });

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -3,6 +3,8 @@ import { spawn } from 'child_process';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
+import { OAuth2Client } from 'google-auth-library';
+import { MongoClient } from 'mongodb';
 import { maybePublishPRForIssue, createEnvContext } from './git-helpers.js';
 
 function run(cmd, args, options = {}) {
@@ -18,11 +20,46 @@ function run(cmd, args, options = {}) {
 
 const sessions = new Map();
 
+const mongoClient = new MongoClient(process.env.MONGO_URL || 'mongodb://localhost:27017');
+await mongoClient.connect();
+const db = mongoClient.db('codexdb');
+const history = db.collection('history');
+
+const oauthClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(express.static(path.join(path.dirname(new URL(import.meta.url).pathname), 'public')));
+
+app.get('/config.js', (req, res) => {
+  res.type('application/javascript');
+  res.send(`export const GOOGLE_CLIENT_ID = '${process.env.GOOGLE_CLIENT_ID || ''}';`);
+});
+
+app.post('/login', async (req, res) => {
+  const { idToken } = req.body;
+  if (!idToken) {
+    res.status(400).send('idToken required');
+    return;
+  }
+  try {
+    const ticket = await oauthClient.verifyIdToken({ idToken, audience: process.env.GOOGLE_CLIENT_ID });
+    const payload = ticket.getPayload();
+    const userId = payload.email;
+    let session = sessions.get(userId);
+    if (!session) {
+      session = { repos: new Map(), home: path.join(os.tmpdir(), `codex-home-${userId}`) };
+      sessions.set(userId, session);
+      await fs.promises.mkdir(session.home, { recursive: true });
+    }
+    res.json({ userId });
+  } catch (err) {
+    console.error(err);
+    res.status(401).send('Invalid token');
+  }
+});
 
 app.post('/run', async (req, res) => {
   const { repoUrl, prompt, token, branch = 'main', userId } = req.body;
@@ -77,11 +114,22 @@ app.post('/run', async (req, res) => {
 
     const ctx = createEnvContext({ ...process.env, GITHUB_TOKEN: token, GITHUB_REPOSITORY: repoUrl.split('github.com/')[1].replace(/\.git$/, '') });
     const prUrl = await maybePublishPRForIssue(1, prompt, ctx);
+    await history.insertOne({ userId, repoUrl, prompt, prUrl: prUrl || null, timestamp: new Date() });
     res.json({ prUrl });
   } catch (err) {
     console.error(err);
     res.status(500).send(err.message);
   }
+});
+
+app.get('/history', async (req, res) => {
+  const { userId, repoUrl } = req.query;
+  if (!userId || !repoUrl) {
+    res.status(400).send('userId and repoUrl required');
+    return;
+  }
+  const items = await history.find({ userId, repoUrl }).sort({ timestamp: 1 }).toArray();
+  res.json(items);
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add google-auth-library and mongodb to the web server
- implement Google OAuth2 login, serve client id to frontend
- persist per-user chat history in MongoDB
- expose `/history` and `/config.js` endpoints
- update frontend for Google sign‑in and history loading
- document new env vars in the README

## Testing
- `node --check web-server/server.js`
- `node --check web-server/public/main.js`
- ❌ `pnpm -v` *(fails: Request was cancelled - proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68872eb0af78832fb47b4d2cb3d1e9aa