### PR TITLE
Add per-user container guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ The server reuses the same clone and creates a pull request for each run.
 
 **Security note:** the server executes commands and uses your token for pushes. Only run it with repositories and credentials you trust.
 
+For an example of running the CLI in per-user containers behind Nginx or Traefik, see [docs/per-user-containers.md](docs/per-user-containers.md).
+
 
 ## Model Context Protocol (MCP)
 

--- a/docs/per-user-containers.md
+++ b/docs/per-user-containers.md
@@ -1,0 +1,79 @@
+# Per-user container deployment
+
+This guide shows how to run Codex CLI in Docker so that each user gets an isolated container. A reverse proxy routes requests to the right instance.
+
+## Build the Codex CLI image
+
+```bash
+docker build -t codex-cli ./codex-cli
+```
+
+The container exposes the CLI on port `3000`.
+
+## Launch a container per user
+
+Start a container for every authenticated user and map it to a unique host port:
+
+```bash
+docker run -d --name codex-alice -p 3001:3000 codex-cli
+docker run -d --name codex-bob   -p 3002:3000 codex-cli
+```
+
+## Nginx example
+
+Configure Nginx to route requests based on the user path:
+
+```nginx
+http {
+    upstream alice { server 127.0.0.1:3001; }
+    upstream bob   { server 127.0.0.1:3002; }
+
+    server {
+        listen 80;
+
+        location /alice/ {
+            proxy_pass http://alice;
+        }
+
+        location /bob/ {
+            proxy_pass http://bob;
+        }
+    }
+}
+```
+
+Your application should map the logged in user to the appropriate path (e.g. `/alice/`).
+
+## Traefik example
+
+Traefik can automatically discover containers via Docker labels. The `docker-compose.yml` below exposes each container on its own subdomain:
+
+```yaml
+version: "3"
+services:
+  traefik:
+    image: traefik:v3.0
+    command:
+      - --providers.docker=true
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  codex-alice:
+    image: codex-cli
+    labels:
+      - "traefik.http.routers.alice.rule=Host(`alice.example.com`)"
+    expose:
+      - "3000"
+
+  codex-bob:
+    image: codex-cli
+    labels:
+      - "traefik.http.routers.bob.rule=Host(`bob.example.com`)"
+    expose:
+      - "3000"
+```
+
+When new containers are started with the correct labels Traefik begins routing to them automatically.


### PR DESCRIPTION
## Summary
- document running the CLI with a container per user using Nginx or Traefik
- cross-link the doc from the web server automation section

## Testing
- `python3 scripts/asciicheck.py README.md`
- `python3 scripts/readme_toc.py README.md`
- `python3 scripts/asciicheck.py docs/per-user-containers.md`

------
https://chatgpt.com/codex/tasks/task_e_688732c29474832fa3fc3974b07d8617